### PR TITLE
fix(plugin): 更新技能市场描述信息

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "teachingai@163.com"
   },
   "metadata": {
-      "description": "Teaching AI 免费技能市场 - 面向期望成为全栈技能人才的群体，提供按技能种类组织的实用工具技能集合。严格遵循 Agent Skills 规范，提供 171 个技能集合，按技能种类组织为 12 个插件类别，覆盖软件开发全生命周期。在 AI 时代，赋能全栈独立开发者，通过 AI 助手掌握专业技能，实现\"一个人 = 一个公司\"的愿景。",
+      "description": "Teaching AI 免费技能市场 - 面向期望成为全栈技能人才的群体，提供按技能种类组织的实用工具技能集合。严格遵循 Agent Skills 规范，提供 169 个技能集合，按技能种类组织为 12 个插件类别，覆盖软件开发全生命周期。在 AI 时代，赋能全栈独立开发者，通过 AI 助手掌握专业技能，实现\"一个人 = 一个公司\"的愿景。",
     "version": "0.0.1"
   },
   "plugins": [
     {
       "name": "development-skills",
-      "description": "全栈开发技能集合（76个技能）：包含前端开发（Vue 2/3、React、Angular、Svelte 等框架；Vite、Webpack 等构建工具；Element Plus、Ant Design、Vant 等 UI 组件库；Vue Router、Pinia、Vuex、Redux 等状态管理；Electron、Tauri 等桌面应用框架）、后端开发（Spring Boot、Spring Cloud、Spring AI 等 Java 生态；Express、NestJS、Koa、Fastify 等 Node.js 框架；Django、FastAPI、Flask 等 Python 框架；Gin 等 Go 框架）、移动端开发（UniApp、UniApp-x 跨平台框架；React Native、Flutter 跨平台框架；Android Kotlin、iOS Swift 原生开发；Cocos2d-x 游戏引擎；uCharts、Lime EChart 图表组件；UniCloud 云开发、Uni-ad 广告变现等）。帮助 AI 助手掌握全栈开发技能，支持 Web、移动端、桌面应用全平台开发。",
+      "description": "全栈开发技能集合（74个技能）：包含前端开发（Vue 2/3、React、Angular、Svelte 等框架；Vite、Webpack 等构建工具；Element Plus、Ant Design、Vant 等 UI 组件库；Vue Router、Pinia、Redux 等状态管理；Electron、Tauri 等桌面应用框架）、后端开发（Spring Boot、Spring Cloud、Spring AI 等 Java 生态；Express、NestJS、Koa、Fastify 等 Node.js 框架；Django、FastAPI、Flask 等 Python 框架；Gin 等 Go 框架）、移动端开发（UniApp、UniApp-x 跨平台框架；React Native、Flutter 跨平台框架；Android Kotlin、iOS Swift 原生开发；Cocos2d-x 游戏引擎；uCharts、Lime EChart 图表组件；UniCloud 云开发、Uni-ad 广告变现等）。帮助 AI 助手掌握全栈开发技能，支持 Web、移动端、桌面应用全平台开发。",
       "source": "./",
       "strict": false,
       "skills": [
@@ -19,7 +19,6 @@
         "./skills/vue3",
         "./skills/vue-router",
         "./skills/pinia",
-        "./skills/vuex",
         "./skills/vite",
         "./skills/react",
         "./skills/react-hooks",
@@ -31,7 +30,6 @@
         "./skills/rollup",
         "./skills/parcel",
         "./skills/rspack",
-        "./skills/element-plus",
         "./skills/element-plus-vue3",
         "./skills/ant-design-vue",
         "./skills/ant-design-react",
@@ -77,7 +75,7 @@
         "./skills/uniapp-ucharts",
         "./skills/uniapp-ad",
         "./skills/uniapp-cloud",
-        "./skills/uniapp-mini-guide",
+        "./skills/uniapp-mini",
         "./skills/uniapp-native-app",
         "./skills/uniapp-native-plugin",
         "./skills/uniapp-plugin",
@@ -95,12 +93,14 @@
     },
     {
       "name": "development-skills-utils",
-      "description": "开发工具技能集合（13个技能）：包含代码生成、测试编写、文档构建等基础工具；DDD 项目构建器（支持单体单模块、单体多模块、微服务架构）；项目文档生成（14种文档模板，覆盖产品到运维全生命周期）；MCP 构建器、Web 应用测试、前端设计、Web 工件构建器、主题工厂；Node.js 版本管理（nvm）、浏览器自动化；Maven 组件检索（从 Maven Central Repository 搜索和检索 Maven 依赖）等。帮助 AI 助手掌握开发工具链和工程化实践。",
+      "description": "开发工具技能集合（15个技能）：包含代码生成、测试编写、文档构建等基础工具；Java 代码注释生成（支持标准 JavaDoc 和 Java 编程规范严格格式）；MyBatis-Plus 代码生成器（支持 MVC 和 DDD 架构，Java 和 Kotlin 语言）；DDD 项目构建器（支持单体单模块、单体多模块、微服务架构）；项目文档生成（14种文档模板，覆盖产品到运维全生命周期）；MCP 构建器、Web 应用测试、前端设计、Web 工件构建器、主题工厂；Node.js 版本管理（nvm）、浏览器自动化；Maven 组件检索（从 Maven Central Repository 搜索和检索 Maven 依赖）等。帮助 AI 助手掌握开发工具链和工程化实践。",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/code-generator",
         "./skills/test-writer",
+        "./skills/java-code-comments",
+        "./skills/mybatis-plus-generator",
         "./skills/ddd4j-project-creator",
         "./skills/documentation-builder",
         "./skills/full-stack-doc",
@@ -158,11 +158,10 @@
     },
     {
       "name": "architecture-skills",
-      "description": "架构技能集合（7个技能）：包含领域驱动设计（DDD）、DDD 微服务架构、DDD 事件驱动架构、DDD 六边形架构、DDD 整洁架构、COLA 架构等架构模式；Draw.io 架构图绘制工具。帮助 AI 助手掌握企业级架构设计、领域建模、架构图绘制等架构设计技能。",
+      "description": "架构技能集合（6个技能）：包含 DDD 微服务架构、DDD 事件驱动架构、DDD 六边形架构、DDD 整洁架构、COLA 架构等架构模式；Draw.io 架构图绘制工具。帮助 AI 助手掌握企业级架构设计、领域建模、架构图绘制等架构设计技能。",
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/ddd",
         "./skills/ddd-cola",
         "./skills/ddd-microservices",
         "./skills/ddd-event-driven",


### PR DESCRIPTION
- 修复总技能数量从 171 个调整为 169 个
- 修正全栈开发技能集合数量从 76 个调整为 74 个
- 移除 vuex 技能引用
- 移除 element-plus 技能引用
- 将 uniapp-mini-guide 重命名为 uniapp-mini
- 增加开发工具技能集合数量从 13 个调整为 15 个
- 添加 java-code-comments 和 mybatis-plus-generator 技能
- 移除 ddd 基础技能，架构技能从 7 个调整为 6 个